### PR TITLE
ensure `hosts_clean` doesn't return an error if tmpfiles dont exist

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Peter Hogg <peter@havenaut.net>
 Jesse Farinacci
 Ryan Yeske <ryan@ryanyeske.com> 
 Baptiste Fontaine <b@ptistefontaine.fr>
+Benjamin Den Hartog <ben@denhartog.io>

--- a/bin/hostsctl.sh
+++ b/bin/hostsctl.sh
@@ -281,7 +281,7 @@ hosts_restore() {
 
 # hosts_clean: remove temporary files created by hostsctl.
 hosts_clean() {
-  rm /tmp/hostsctl-* 2> /dev/null
+  trap 'rm /tmp/hostsctl-*'
 }
 
 # hosts_init: initialize required files.


### PR DESCRIPTION
- [x] This pull request isn't a duplicate of an [existing one][1]
- [x] No existing features have been broken
- [x] Commit messages are detailed
- [x] The [code style guidelines][2] have been followed
- [x] Documentation has been updated to reflect changes
- [ ] Tests have been added / updated to reflect changes

---

* What changes does this pull request make?
Fixes an erroneous status code from being returned on successful operations that do not create any files that match `rm /tmp/hostsctl-*`.

* What is the current behavior?
On operations that do not create any (persistent) files that match the pattern used in `hosts_clean()`, an error code is returned even if the operation is successful.

For example, `hostsctl disable <host>` or `hostsctl enable <host>`.

* Does this pull request introduce any breaking changes?
No

---

**commit message:**

`rm` returns an error code if the argument does not exist, causing
`hostsctl` to return an error code whenever the `hosts_clean` function
"fails", even if `hostsctl` performed a successful operation.

closes #2

[1]: https://github.com/pigmonkey/hostsctl/pulls
[2]: https://github.com/pigmonkey/hostsctl/blob/master/.github/CONTRIBUTING.md#code-style
