### PR TITLE
refactor hosts_restore to persist changes made to /etc/hosts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,4 +16,4 @@ Peter Hogg <peter@havenaut.net>
 Jesse Farinacci
 Ryan Yeske <ryan@ryanyeske.com> 
 Baptiste Fontaine <b@ptistefontaine.fr>
-Benjamin Den Hartog <ben@denhartog.io>
+Benjamin Den Hartog <www.sudoforge.com>

--- a/bin/hostsctl.sh
+++ b/bin/hostsctl.sh
@@ -270,11 +270,16 @@ hosts_update() {
   hosts_merge
 }
 
-# hosts_restore: restore original /etc/hosts temporary.
+# hosts_restore: remove remote and explicitly disabled hosts from /etc/hosts
 hosts_restore() {
   root_check
 
-  cp ${USER_HOSTS} /etc/hosts
+  grep --fixed-strings --line-regexp --invert-match \
+      -f ${REMOTE_HOSTS} \
+      -f ${DISABLED_HOSTS} \
+      ${HOSTS} > ${USER_HOSTS}
+
+  cp ${USER_HOSTS} ${HOSTS}
   msg_check "${HOSTS} has been restored."
   msg_info  "run ${yellow}\'hostsctl merge\'${reset} to undo."
 }


### PR DESCRIPTION
This patch uses `grep` to find any entries in `/etc/hosts` which do not exist in `/etc/hostsctl/remote.hosts` or `/etc/hostctl/disabled.hosts`, and replaces the contents in `/etc/hostsctl/orig.hosts` with these values.

This helps to persist manual changes that are made to `/etc/hosts`, such as adding new entries or updating existing custom entries.

---

See issue #4.