### PR TITLE
fix export command for scripts

### DIFF
--- a/bin/hostsctl.sh
+++ b/bin/hostsctl.sh
@@ -16,9 +16,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# Reset tty colors if running in a tty.
+maybe_reset_tty_colors() {
+  local mytty
+  # The `tty` command returns an error if not running in a tty.
+  mytty="$(tty)" || return
+  tput sgr0 > "${mytty}"
+}
+
 # by https://github.com/mathiasbynens/dotfiles
 if tput setaf 1 &> /dev/null; then
-  tput sgr0; # reset colors
+  maybe_reset_tty_colors
   bold=$(tput bold);
   reset=$(tput sgr0);
   # Solarized colors, taken from http://git.io/solarized-colors.


### PR DESCRIPTION
hoststl used to always reset the terminal colors, even when redirecting
its output, which made it output the terminal control codes in the
export command as well.
To see the problematic behavior, run the following on master: `sudo hostsctl export | head -1 | cat -v`